### PR TITLE
fix: use proper certificate pool instead of InsecureSkipVerify

### DIFF
--- a/.changeset/fix-whud-tls-secure.md
+++ b/.changeset/fix-whud-tls-secure.md
@@ -1,0 +1,9 @@
+---
+"eratemanager": patch
+---
+
+Use proper certificate pool instead of InsecureSkipVerify for WHUD
+
+Embed the GoDaddy G2 intermediate certificate for servers that don't send
+complete certificate chains. This maintains proper TLS verification while
+working around misconfigured servers like whud.org.

--- a/internal/rates/http.go
+++ b/internal/rates/http.go
@@ -2,20 +2,74 @@ package rates
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"net/http"
 	"time"
 )
 
-// NewHTTPClient creates an HTTP client with optional TLS configuration.
-// Set skipTLSVerify to true for servers with misconfigured certificate chains
-// (e.g., servers that don't send intermediate certificates).
-func NewHTTPClient(timeout time.Duration, skipTLSVerify bool) *http.Client {
-	transport := &http.Transport{}
+// GoDaddyG2IntermediateCert is the GoDaddy Secure Certificate Authority - G2
+// intermediate certificate. Some servers (like whud.org) don't send intermediate
+// certificates in their chain, so we include it here to enable proper verification.
+// Downloaded from: https://certs.godaddy.com/repository/gdig2.crt.pem
+// Valid until: 2031-05-03
+const GoDaddyG2IntermediateCert = `-----BEGIN CERTIFICATE-----
+MIIE0DCCA7igAwIBAgIBBzANBgkqhkiG9w0BAQsFADCBgzELMAkGA1UEBhMCVVMx
+EDAOBgNVBAgTB0FyaXpvbmExEzARBgNVBAcTClNjb3R0c2RhbGUxGjAYBgNVBAoT
+EUdvRGFkZHkuY29tLCBJbmMuMTEwLwYDVQQDEyhHbyBEYWRkeSBSb290IENlcnRp
+ZmljYXRlIEF1dGhvcml0eSAtIEcyMB4XDTExMDUwMzA3MDAwMFoXDTMxMDUwMzA3
+MDAwMFowgbQxCzAJBgNVBAYTAlVTMRAwDgYDVQQIEwdBcml6b25hMRMwEQYDVQQH
+EwpTY290dHNkYWxlMRowGAYDVQQKExFHb0RhZGR5LmNvbSwgSW5jLjEtMCsGA1UE
+CxMkaHR0cDovL2NlcnRzLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkvMTMwMQYDVQQD
+EypHbyBEYWRkeSBTZWN1cmUgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IC0gRzIwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC54MsQ1K92vdSTYuswZLiBCGzD
+BNliF44v/z5lz4/OYuY8UhzaFkVLVat4a2ODYpDOD2lsmcgaFItMzEUz6ojcnqOv
+K/6AYZ15V8TPLvQ/MDxdR/yaFrzDN5ZBUY4RS1T4KL7QjL7wMDge87Am+GZHY23e
+cSZHjzhHU9FGHbTj3ADqRay9vHHZqm8A29vNMDp5T19MR/gd71vCxJ1gO7GyQ5HY
+pDNO6rPWJ0+tJYqlxvTV0KaudAVkV4i1RFXULSo6Pvi4vekyCgKUZMQWOlDxSq7n
+eTOvDCAHf+jfBDnCaQJsY1L6d8EbyHSHyLmTGFBUNUtpTrw700kuH9zB0lL7AgMB
+AAGjggEaMIIBFjAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAdBgNV
+HQ4EFgQUQMK9J47MNIMwojPX+2yz8LQsgM4wHwYDVR0jBBgwFoAUOpqFBxBnKLbv
+9r0FQW4gwZTaD94wNAYIKwYBBQUHAQEEKDAmMCQGCCsGAQUFBzABhhhodHRwOi8v
+b2NzcC5nb2RhZGR5LmNvbS8wNQYDVR0fBC4wLDAqoCigJoYkaHR0cDovL2NybC5n
+b2RhZGR5LmNvbS9nZHJvb3QtZzIuY3JsMEYGA1UdIAQ/MD0wOwYEVR0gADAzMDEG
+CCsGAQUFBwIBFiVodHRwczovL2NlcnRzLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkv
+MA0GCSqGSIb3DQEBCwUAA4IBAQAIfmyTEMg4uJapkEv/oV9PBO9sPpyIBslQj6Zz
+91cxG7685C/b+LrTW+C05+Z5Yg4MotdqY3MxtfWoSKQ7CC2iXZDXtHwlTxFWMMS2
+RJ17LJ3lXubvDGGqv+QqG+6EnriDfcFDzkSnE3ANkR/0yBOtg2DZ2HKocyQetawi
+DsoXiWJYRBuriSUBAA/NxBti21G00w9RKpv0vHP8ds42pM3Z2Czqrpv1KrKQ0U11
+GIo/ikGQI31bS/6kA1ibRrLDYGCD+H1QQc7CoZDDu+8CL9IVVO5EFdkKrqeKM+2x
+LXY2JtwE65/3YR8V3Idv7kaWKK2hJn0KCacuBKONvPi8BDAB
+-----END CERTIFICATE-----`
 
-	if skipTLSVerify {
-		transport.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: true,
-		}
+// NewHTTPClient creates an HTTP client with the specified timeout.
+func NewHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout: timeout,
+	}
+}
+
+// DefaultHTTPClient returns a standard HTTP client with 30s timeout.
+func DefaultHTTPClient() *http.Client {
+	return NewHTTPClient(30 * time.Second)
+}
+
+// HTTPClientWithExtraCerts returns an HTTP client that includes additional
+// intermediate certificates for servers that don't send complete certificate chains.
+// This is more secure than InsecureSkipVerify because it still validates certificates.
+func HTTPClientWithExtraCerts(timeout time.Duration) *http.Client {
+	// Get the system certificate pool
+	rootCAs, err := x509.SystemCertPool()
+	if err != nil || rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
+
+	// Add the GoDaddy intermediate certificate
+	rootCAs.AppendCertsFromPEM([]byte(GoDaddyG2IntermediateCert))
+
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs: rootCAs,
+		},
 	}
 
 	return &http.Client{
@@ -24,14 +78,8 @@ func NewHTTPClient(timeout time.Duration, skipTLSVerify bool) *http.Client {
 	}
 }
 
-// DefaultHTTPClient returns a standard HTTP client with 30s timeout.
-func DefaultHTTPClient() *http.Client {
-	return NewHTTPClient(30*time.Second, false)
-}
-
-// InsecureHTTPClient returns an HTTP client that skips TLS verification.
-// Use this for servers with broken certificate chains (missing intermediate certs).
-// WARNING: This disables certificate verification. Only use for known servers.
-func InsecureHTTPClient() *http.Client {
-	return NewHTTPClient(30*time.Second, true)
+// WHUDHTTPClient returns an HTTP client configured to work with WHUD's server,
+// which has an incomplete certificate chain (missing intermediate certs).
+func WHUDHTTPClient() *http.Client {
+	return HTTPClientWithExtraCerts(30 * time.Second)
 }

--- a/internal/rates/parser_whud_html.go
+++ b/internal/rates/parser_whud_html.go
@@ -19,9 +19,9 @@ func init() {
 
 // ParseWHUDRatesFromURL fetches the WHUD rates page and extracts water/sewer rates.
 func ParseWHUDRatesFromURL(url string) (*WaterRatesResponse, error) {
-	// WHUD server has a misconfigured SSL certificate chain (missing intermediate certs).
-	// We use an insecure client as a workaround.
-	client := InsecureHTTPClient()
+	// WHUD server doesn't send intermediate certificates in its chain.
+	// Use a client with the GoDaddy intermediate cert to enable proper verification.
+	client := WHUDHTTPClient()
 	resp, err := client.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("fetch WHUD rates page: %w", err)


### PR DESCRIPTION
## Summary
Replace `InsecureSkipVerify: true` with a proper certificate pool that includes the GoDaddy G2 intermediate certificate.

## Problem
The WHUD server (whud.org) has a misconfigured SSL certificate chain - it doesn't send intermediate certificates. This causes TLS verification to fail.

## Solution
Instead of disabling certificate verification entirely with `InsecureSkipVerify`, we:
1. Embed the GoDaddy G2 intermediate certificate (valid until 2031-05-03)
2. Add it to Go's system certificate pool
3. Use this enhanced pool for TLS verification

This approach:
- ✅ Maintains proper TLS certificate validation
- ✅ Only trusts the specific intermediate cert needed
- ✅ Works with any server using GoDaddy certificates
- ✅ No security compromise

## Changes
- `internal/rates/http.go`: Added `GoDaddyG2IntermediateCert` constant and `HTTPClientWithExtraCerts()` / `WHUDHTTPClient()` functions
- `internal/rates/parser_whud_html.go`: Use `WHUDHTTPClient()` instead of `InsecureHTTPClient()`